### PR TITLE
Add PR response data

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ const Octokit = require('@octokit/rest')
 
 const octokit = new Octokit()
 
+// Returns a normal Octokit PR response
+// See https://octokit.github.io/rest.js/#octokit-routes-pulls-create
 octokit.createPullRequest({
   owner: 'repo-name',
   repo: 'repo-name',
@@ -38,7 +40,7 @@ octokit.createPullRequest({
     },
     commit: 'creating file1.txt & file2.txt'
   }
-})
+}).then(pr => console.log(pr.data.number))
 ```
 
 ## Todos

--- a/lib/create-pull-request.js
+++ b/lib/create-pull-request.js
@@ -71,7 +71,7 @@ async function createPullRequest(
     ref: `refs/heads/${head}`
   })
 
-  response = await octokit.pulls.create({
+  return await octokit.pulls.create({
     owner,
     repo,
     head: `${fork}:${head}`,

--- a/test/happy-path-test.js
+++ b/test/happy-path-test.js
@@ -5,6 +5,7 @@ const Octokit = require('@octokit/rest')
 
 test('happy path', async t => {
   const fixtures = require('./fixtures/happy-path')
+  const fixturePr = fixtures[fixtures.length-1].response;
   const octokit = new Octokit()
 
   octokit.hook.wrap('request', (_, options) => {
@@ -20,7 +21,7 @@ test('happy path', async t => {
     return currentFixtures.response
   })
 
-  await octokit.createPullRequest({
+  const pr = await octokit.createPullRequest({
     owner: 'gr2m',
     repo: 'pull-request-test',
     title: 'One comes, one goes',
@@ -35,6 +36,7 @@ test('happy path', async t => {
     }
   })
 
+  t.deepEqual(pr, fixturePr)
   t.equal(fixtures.length, 0)
 })
 


### PR DESCRIPTION
This pull request intends to make the following changes:

 - Return the PR creation response data
 - Document this in the README file

This closes #13 

-----
[View rendered README.md](https://github.com/MattIPv4/octokit-create-pull-request/blob/add-pr-response/README.md)